### PR TITLE
Fix /api/extensions returning an empty list

### DIFF
--- a/src/main/kotlin/com/reburp/OpenApiSpec.kt
+++ b/src/main/kotlin/com/reburp/OpenApiSpec.kt
@@ -1701,8 +1701,7 @@ fun openApiJson(port: Int): String = """
                       "name":    { "type": "string" },
                       "enabled": { "type": "boolean" },
                       "type":    { "type": "string" },
-                      "file":    { "type": "string" },
-                      "errors":  { "type": "string" }
+                      "file":    { "type": "string" }
                     }
                   }
                 }

--- a/src/main/kotlin/com/reburp/routes/ConfigRoutes.kt
+++ b/src/main/kotlin/com/reburp/routes/ConfigRoutes.kt
@@ -90,16 +90,16 @@ fun Routing.configRoutes(api: MontoyaApi) {
         runCatching {
             val json = api.burpSuite().exportUserOptionsAsJson()
             val root = Json.parseToJsonElement(json).jsonObject
-            val exts = root["extender"]?.jsonObject?.get("extensions")?.jsonArray
+            val exts = root["user_options"]?.jsonObject?.get("extender")?.jsonObject?.get("extensions")?.jsonArray
+                ?: root["extender"]?.jsonObject?.get("extensions")?.jsonArray
                 ?: root["extensions"]?.jsonObject?.get("extensions")?.jsonArray
                 ?: JsonArray(emptyList())
             val result = exts.mapNotNull { it.jsonObject }.map { ext ->
                 buildJsonObject {
-                    put("name",    ext["name"]    ?: JsonPrimitive("unknown"))
-                    put("enabled", ext["loaded"]  ?: ext["enabled"] ?: JsonPrimitive(false))
-                    put("type",    ext["type"]    ?: JsonPrimitive("java"))
-                    put("file",    ext["filename"]?: ext["file"]    ?: JsonPrimitive(""))
-                    put("errors",  ext["errors"]  ?: JsonPrimitive(""))
+                    put("name",    ext["name"]          ?: JsonPrimitive("unknown"))
+                    put("enabled", ext["loaded"]        ?: ext["enabled"] ?: JsonPrimitive(false))
+                    put("type",    ext["extension_type"]?: ext["type"]    ?: JsonPrimitive("java"))
+                    put("file",    ext["extension_file"]?: ext["filename"]?: ext["file"] ?: JsonPrimitive(""))
                 }
             }
             call.respond(result)


### PR DESCRIPTION
## Summary
`GET /api/extensions` always returned `[]`: it looked up
`extender.extensions` at the root of `exportUserOptionsAsJson()`,
but the export wraps everything under `user_options`.

- Resolve `user_options.extender.extensions` first; previous paths
  kept as fallbacks for older export shapes
- Map the real entry fields `extension_type` / `extension_file`
  (type previously always reported "java", file was always empty)
- Drop `errors` from the response and OpenAPI schema: that config
  key holds the error output stream preference ("ui"), not error
  content, and the endpoint description only promises
  name/enabled/type/file

#### Test plan
- [x] `./gradlew shadowJar` builds clean
- [x] `python3 tools/api_coverage.py` — 100% of mappable surface
- [x] Live test: patched jar in Burp Pro 2026.x returns all 17 of my 
      loaded extensions with correct names, enabled state, types
      (java/python), and file paths